### PR TITLE
Migrate all the D-Bus calls to GDBus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,10 @@ BlueZ also provides an interactive commandline tool to interact with Bluetooth d
 
 ### Installing GATT SDK for Python
 
-To install this GATT module and the Python3 D-Bus dependency globally, run:
+To install this GATT module globally, run:
 
 ```
 sudo pip3 install gatt
-sudo apt-get install python3-dbus
 ```
 
 #### Running the GATT control script


### PR DESCRIPTION
Disclaimer: This pull-request does not "fix" an "issue" but is rather a proposal and is a 1:1 migration. I plan on expanding on that idea, creating proper DBusProxy subclasses, somehow resect the requirement for a non-user-controlled mainloop and thus improve the integratability of gatt-python for my own projects. If you think this migration is rubbish, just close the pull-request ;-)

--

Given that the python-dbus interface only receives fixes and is considered by
its author and maintainer as un-pythonic and is not recommended by him, it seems
more logical to use another, more recommendable interface.

As gatt-python already makes use of PyGI and GLib, it makes sense to use GDBus which
comes as a part of GLib.

This also effectively removes the python-dbus dependency.