### PR TITLE
Fix: can't handle sigint when running gatt.DeviceManager outside the mainthread

### DIFF
--- a/gatt/gatt_linux.py
+++ b/gatt/gatt_linux.py
@@ -86,7 +86,7 @@ class DeviceManager:
             self._properties_changed_signal.remove()
             self._interface_added_signal.remove()
 
-        self._main_loop = GObject.MainLoop()
+        self._main_loop = GObject.MainLoop.new(None, False)
         try:
             self._main_loop.run()
             disconnect_signals()


### PR DESCRIPTION
I discovered that it was impossible to set a signal handler for SIGINT in combination with a running gatt.DeviceManager. 

Code to reproduce (pseudocode):

```
def main():
    def trap_sigint(*args, **kwargs):
        logging.info("SIGNAL SIGINT")

    # SIGINT (2)
    signal.signal(signal.SIGINT, trap_sigint)

    def run_gatt_devicemanager:
        import gatt
        dm =  gatt.DeviceManager()
        dm.run()

     t = Thread(target=run_gatt_devicemanager)
     t.start()
     t.join()
```

This code raises a ``KeyboardInterrupt`` exception when ``SIGINT`` was received which is quite unexpected as a signal handler for ``SIGINT`` was set.

Also fix subissue related to CTRL + C, which is a ``SIGINT`` in fact, of https://github.com/getsenic/gatt-python/issues/5#issuecomment-313362380 . The fix in my pull request was retrieved from https://stackoverflow.com/a/47947420 .