### PR TITLE
#35  Proposes an extension to access GATT descriptors

### DIFF
--- a/examples/read_descriptor.py
+++ b/examples/read_descriptor.py
@@ -1,0 +1,45 @@
+import gatt
+
+from argparse import ArgumentParser
+
+
+class AnyDevice(gatt.Device):
+    def connect_succeeded(self):
+        super().connect_succeeded()
+        print("[%s] Connected" % (self.mac_address))
+
+    def connect_failed(self, error):
+        super().connect_failed(error)
+        print("[%s] Connection failed: %s" % (self.mac_address, str(error)))
+
+    def disconnect_succeeded(self):
+        super().disconnect_succeeded()
+        print("[%s] Disconnected" % (self.mac_address))
+
+    def services_resolved(self):
+        super().services_resolved()
+
+        print("[%s] Resolved services" % (self.mac_address))
+        for service in self.services:
+            print("[%s]\tService [%s]" % (self.mac_address, service.uuid))
+            for characteristic in service.characteristics:
+                print("[%s]\t\tCharacteristic [%s]" % (self.mac_address, characteristic.uuid))
+                for descriptor in characteristic.descriptors:
+                    print("[%s]\t\t\tDescriptor [%s] (%s)" % (self.mac_address, descriptor.uuid, descriptor.read_value()))
+
+    def descriptor_read_value_failed(self, descriptor, error):
+        print('descriptor_value_failed')
+
+
+arg_parser = ArgumentParser(description="GATT Connect Demo")
+arg_parser.add_argument('mac_address', help="MAC address of device to connect")
+args = arg_parser.parse_args()
+
+print("Connecting...")
+
+manager = gatt.DeviceManager(adapter_name='hci0')
+
+device = AnyDevice(manager=manager, mac_address=args.mac_address)
+device.connect()
+
+manager.run()

--- a/gatt/gatt_linux.py
+++ b/gatt/gatt_linux.py
@@ -557,14 +557,12 @@ class Characteristic:
         self._properties = dbus.Interface(self._object, "org.freedesktop.DBus.Properties")
         self._properties_signal = None
 
-        # extract the descriptions from the paths obtained via dbus. They end with /descXXXX.
-        self.descriptors = []
         descriptor_regex = re.compile(self._path + '/desc[0-9abcdef]{4}$')
-        managed_descriptors = [desc for desc in self._object_manager.GetManagedObjects().items() if
-                               descriptor_regex.match(desc[0])]
-
-        for desc in managed_descriptors:
-            self.descriptors.append(Descriptor(self, desc[0], desc[1]['org.bluez.GattDescriptor1']['UUID']))
+        self.descriptors = [
+            Descriptor(self, desc[0], desc[1]['org.bluez.GattDescriptor1']['UUID'])
+            for desc in self._object_manager.GetManagedObjects().items()
+            if descriptor_regex.match(desc[0])
+        ]
 
     def _connect_signals(self):
         if self._properties_signal is None:


### PR DESCRIPTION
This proposes an extension to gatt-python to be able to read out
the value of GATT descriptors of characteristics as well. Those
descriptors can contain metadata and configuration information
for their characteristic.

This could fix my request in #35 