### PR TITLE
Added timeout-option/parameter to start_discovery(...)

### DIFF
--- a/examples/discovery.py
+++ b/examples/discovery.py
@@ -5,5 +5,5 @@ class AnyDeviceManager(gatt.DeviceManager):
         print("[%s] Discovered, alias = %s" % (device.mac_address, device.alias()))
 
 manager = AnyDeviceManager(adapter_name='hci0')
-manager.start_discovery()
+manager.start_discovery(timeout=10000) # 10 seconds
 manager.run()

--- a/gatt/gatt_linux.py
+++ b/gatt/gatt_linux.py
@@ -124,11 +124,14 @@ class DeviceManager:
         self.update_devices()
         return self._devices.values()
 
-    def start_discovery(self, service_uuids=[]):
+    def start_discovery(self, service_uuids=[], timeout=None):
         """Starts a discovery for BLE devices with given service UUIDs.
 
         :param service_uuids: Filters the search to only return devices with given UUIDs.
+        :param timeout: Stops discovery after a timeout (in milliseconds).
         """
+        if timeout is not None:
+            GObject.timeout_add(timeout, self.stop)
 
         discovery_filter = {'Transport': 'le'}
         if service_uuids:  # D-Bus doesn't like empty lists, it needs to guess the type

--- a/gatt/gatt_linux.py
+++ b/gatt/gatt_linux.py
@@ -124,13 +124,13 @@ class DeviceManager:
         self.update_devices()
         return self._devices.values()
 
-    def start_discovery(self, service_uuids=[], timeout=None):
+    def start_discovery(self, service_uuids=[], timeout=10000):
         """Starts a discovery for BLE devices with given service UUIDs.
 
         :param service_uuids: Filters the search to only return devices with given UUIDs.
-        :param timeout: Stops discovery after a timeout (in milliseconds).
+        :param timeout: Stops discovery after a timeout (in milliseconds). If set to 0, no timeout is used.
         """
-        if timeout is not None:
+        if timeout > 0:
             GObject.timeout_add(timeout, self.stop)
 
         discovery_filter = {'Transport': 'le'}


### PR DESCRIPTION
I had to re-open this [pull-request](https://github.com/getsenic/gatt-python/pull/38), because I deleted my first fork of gatt-python. I'm sorry for that.

But I've now implemented blumberg's suggestion.